### PR TITLE
Use CORS proxy to fetch Open Graph tags for websites that do not have…

### DIFF
--- a/src/components/link-preview/open-graph.jsx
+++ b/src/components/link-preview/open-graph.jsx
@@ -8,7 +8,7 @@ export default function OpenGraphPreview({ url }) {
       return;
     }
     async function fetchData() {
-      const response = await fetch(url);
+      const response = await fetch(`https://corsproxy.io/?${encodeURIComponent(url)}`);
       const html = await response.text();
       const doc = new DOMParser().parseFromString(html, 'text/html');
 


### PR DESCRIPTION
… CORS access.

This change will allow us to display link previews for websites that we were not able to display them for before.

Please give a short description of what would change if this PR is merged. Attach screenshots (or, better, gifs) of any changes that are visible to users, if possible.
